### PR TITLE
Add support for file uploads

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -36,6 +36,16 @@ There wasn't a gem out there, so I wrote one.
     puts calls.index(call).to_s + ": " + c.start_time + ": " + c.from + " " + c.to
   end
 
+  # Methods that require a file upload can be submitted with the upload method
+  upload = switchvox.upload("switchvox.file.add", {
+    "file"  => "/path/to/file.ext"
+  })
+
+  upload = switchvox.upload("switchvox.images.add", {
+    "image_file"  => "/path/to/file.ext",
+    "image_type"  => "profile"
+  })
+
 == REQUIREMENTS:
 
 * json gem

--- a/lib/switchvox/base.rb
+++ b/lib/switchvox/base.rb
@@ -27,7 +27,7 @@ end
 class Base
 
   URL = "/json"
-  BOUNDRY = "---------------------------7d44e178b0434"
+  BOUNDARY = "---------------------------7d44e178b0434"
   attr :host, true
   attr :url, true
   attr :user, false
@@ -65,7 +65,7 @@ class Base
 
   def upload(method, parameters={})
     body = multipart_upload(method, parameters)
-    header = {'Content-Type' => 'multipart/form-data; boundry=' + BOUNDRY}
+    header = {'Content-Type' => 'multipart/form-data; boundary=' + BOUNDARY}
     send_request(body, header)
   end
 
@@ -125,16 +125,16 @@ class Base
       # build the body of the request
       # add the file data
       post_body = []
-      post_body << "--#{BOUNDRY}\r\n"
+      post_body << "--#{BOUNDARY}\r\n"
       post_body << "Content-Disposition: form-data; name=\"file\"; filename=\"#{File.basename(file)}\"\r\n"
       post_body << "Content-Type: #{MIME::Types.type_for(file)[0]}\r\n\r\n"
       post_body << File.read(file)
 
       # add the json with the method name
-      post_body << "--#{BOUNDRY}\r\n"
+      post_body << "--#{BOUNDARY}\r\n"
       post_body << "Content-Disposition: form-data; name=\"request\"\r\n\r\n"
       post_body << json
-      post_body << "\r\n\r\n--#{BOUNDRY}--\r\n"
+      post_body << "\r\n\r\n--#{BOUNDARY}--\r\n"
       return post_body.join
     end
 

--- a/spec/switchvox/base_spec.rb
+++ b/spec/switchvox/base_spec.rb
@@ -19,7 +19,7 @@ describe Switchvox::Base do
     # add a public instance to a private method for testing
     # create a test file
     before(:all) do
-      module Switchvox; class Base; def public_multipart_upload(f); multipart_upload(f); end; end; end
+      module Switchvox; class Base; def public_multipart_upload(m, f); multipart_upload(m, f); end; end; end
       File.open "/tmp/testfile.xml", "w" do |file|
         file.write("<element></element>")
       end
@@ -27,11 +27,11 @@ describe Switchvox::Base do
     end
 
     it "should return a string" do
-      switchvox.public_multipart_upload(@file).class.should eq String
+      switchvox.public_multipart_upload("switchvox.file.add", image_file: @file).class.should eq String
     end
 
     it "should return form data" do
-      switchvox.public_multipart_upload(@file).should include "Content-Disposition: form-data;"
+      switchvox.public_multipart_upload("switchvox.file.add", image_file: @file).should include "Content-Disposition: form-data;"
     end
   end
 

--- a/spec/switchvox/base_spec.rb
+++ b/spec/switchvox/base_spec.rb
@@ -14,6 +14,27 @@ describe Switchvox::Base do
     Hash['response', Hash['result', body]].to_json
   end
 
+  describe "multipart_upload" do
+
+    # add a public instance to a private method for testing
+    # create a test file
+    before(:all) do
+      module Switchvox; class Base; def public_multipart_upload(f); multipart_upload(f); end; end; end
+      File.open "/tmp/testfile.xml", "w" do |file|
+        file.write("<element></element>")
+      end
+      @file = "/tmp/testfile.xml"
+    end
+
+    it "should return a string" do
+      switchvox.public_multipart_upload(@file).class.should eq String
+    end
+
+    it "should return form data" do
+      switchvox.public_multipart_upload(@file).should include "Content-Disposition: form-data;"
+    end
+  end
+
   describe 'parse json and return object' do
     it 'should test_object' do
       input = {"string" => "value"}


### PR DESCRIPTION
Adds support for uploading files with the `uploads` method. Also abstracts the request logic to a private method that both the `uploads` and `requests` methods can use.
